### PR TITLE
feat: update node-minimatch to 9.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-/dist
-/coverage
-/node_modules

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+node-minimatch (9.0.3-5) unstable; urgency=medium
+
+  * Team upload
+  * Declare compliance with policy 4.7.0
+  * Build bundled version (Closes: #1079833)
+
+ -- Yadd <yadd@debian.org>  Wed, 28 Aug 2024 12:39:36 +0200
+
 node-minimatch (9.0.3-4) unstable; urgency=medium
 
   * Team upload

--- a/debian/control
+++ b/debian/control
@@ -7,10 +7,14 @@ Priority: optional
 Build-Depends: debhelper-compat (= 13)
  , dh-sequence-nodejs
  , node-brace-expansion <!nocheck>
+ , node-rollup-plugin-commonjs
+ , node-rollup-plugin-node-resolve
+ , node-rollup-plugin-terser
  , node-tap (>= 15) <!nocheck>
  , node-types-brace-expansion
+ , rollup
  , ts-node
-Standards-Version: 4.6.2
+Standards-Version: 4.7.0
 Vcs-Browser: https://salsa.debian.org/js-team/node-minimatch
 Vcs-Git: https://salsa.debian.org/js-team/node-minimatch.git
 Homepage: https://github.com/isaacs/minimatch

--- a/debian/nodejs/extlinks
+++ b/debian/nodejs/extlinks
@@ -1,3 +1,4 @@
+brace-expansion
 ts-node		test
 @types/brace-expansion
 @types/node

--- a/debian/patches/keep-old-behavior.patch
+++ b/debian/patches/keep-old-behavior.patch
@@ -3,8 +3,8 @@ Author: Yadd <yadd@debian.org>
 Forwarded: not-needed
 Last-Update: 2023-09-22
 
---- node-minimatch-9.0.3.orig/package.json
-+++ node-minimatch-9.0.3/package.json
+--- a/package.json
++++ b/package.json
 @@ -7,7 +7,7 @@
      "type": "git",
      "url": "git://github.com/isaacs/minimatch.git"

--- a/debian/rules
+++ b/debian/rules
@@ -11,4 +11,5 @@ override_dh_auto_build:
 	tsc
 	tsc -p tsconfig-esm.json
 	echo '{"type":"module"}' >dist/mjs/package.json
+	rollup -m --format=commonjs -p @rollup/plugin-commonjs -p @rollup/plugin-node-resolve -p rollup-plugin-terser --file=dist/cjs/index.bundle.js -- dist/cjs/index.js
 	cp debian/index.js .


### PR DESCRIPTION
Convert glob expressions into RegExp objects for Node.js

Issue: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/558
Log: update repo
